### PR TITLE
fix: get filename from helper by default

### DIFF
--- a/KS.Fiks.Arkiv.Integration.Tests/FiksIO/FiksRequestMessageService.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/FiksIO/FiksRequestMessageService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using KS.Fiks.Arkiv.Models.V1.Meldingstyper;
 using KS.Fiks.IO.Client;
 using KS.Fiks.IO.Client.Configuration;
 using KS.Fiks.IO.Client.Models;
@@ -30,9 +31,13 @@ namespace KS.Fiks.Arkiv.Integration.Tests.FiksIO
         
         private Task Initialization { get; set; }
 
-        public async Task<Guid> Send(Guid mottakerKontoId, string meldingsType, string payloadContent, string payloadFilename, List<KeyValuePair<string, FileStream>>? attachments, string testSessionId)
+        public async Task<Guid> Send(Guid mottakerKontoId, string meldingsType, string payloadContent, List<KeyValuePair<string, FileStream>>? attachments, string testSessionId, string payloadFilename = null)
         {
             await Initialization;
+            if (payloadFilename == null)
+            {
+                payloadFilename = FiksArkivPayloadHelper.GetPayloadFilnavn(meldingsType);
+            }
             
             var headere = new Dictionary<string, string>() { { "testSessionId", testSessionId } };
             var ttl = new TimeSpan(0, TTLMinutes, 0);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostMedRegelTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostMedRegelTests.cs
@@ -101,7 +101,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             validator.Validate(nyJournalpostSerialized);
 
             // Send melding
-            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, "arkivmelding.xml", null, testSessionId);
+            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, null, testSessionId);
             
             // Vent på 2 første response meldinger (mottatt og kvittering)
             VentPaSvar(2, 10);
@@ -138,7 +138,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             MottatMeldingArgsList.Clear();
             
             // Send hent melding
-            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentAsString, "arkivmelding.xml", null, testSessionId);
+            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentAsString, null, testSessionId);
 
             // Vent på 1 respons meldinger 
             VentPaSvar(1, 10);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostTests.cs
@@ -96,7 +96,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             validator.Validate(nyJournalpostSerialized);
 
             // Send melding
-            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, "arkivmelding.xml", null, testSessionId);
+            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, null, testSessionId);
             
             // Vent på 2 første response meldinger (mottatt og kvittering)
             VentPaSvar(2, 10);
@@ -133,7 +133,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             MottatMeldingArgsList.Clear();
             
             // Send hent melding
-            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentAsString, "arkivmelding.xml", null, testSessionId);
+            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentAsString, null, testSessionId);
 
             // Vent på 1 respons meldinger 
             VentPaSvar(1, 10);
@@ -219,7 +219,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             validator.Validate(nyJournalpostSerialized);
 
             // Send melding
-            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, "arkivmelding.xml", null, testSessionId);
+            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, null, testSessionId);
             
             // Vent på 2 første response meldinger (mottatt og kvittering)
             VentPaSvar(2, 10);
@@ -256,7 +256,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             MottatMeldingArgsList.Clear();
             
             // Send hent melding
-            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentAsString, "arkivmelding.xml", null, testSessionId);
+            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentAsString, null, testSessionId);
 
             // Vent på 1 respons meldinger 
             VentPaSvar(1, 10);
@@ -340,7 +340,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             validator.Validate(nyJournalpostSerialized);
 
             // Send melding
-            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, "arkivmelding.xml", null, testSessionId);
+            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, null, testSessionId);
             
             // Vent på 2 første response meldinger (mottatt og kvittering)
             VentPaSvar(2, 10);
@@ -377,7 +377,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             MottatMeldingArgsList.Clear();
             
             // Send hent melding
-            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentAsString, "arkivmelding.xml", null, testSessionId);
+            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentAsString, null, testSessionId);
 
             // Vent på 1 respons meldinger 
             VentPaSvar(1, 10);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/ArkivmeldingOppdatering/OppdaterOgHentJournalpostTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/ArkivmeldingOppdatering/OppdaterOgHentJournalpostTests.cs
@@ -66,7 +66,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             validator.Validate(nyJournalpostSerialized);
 
             // Send melding
-            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, "arkivmelding.xml", null, testSessionId);
+            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized,  null, testSessionId);
             
             // Vent på 2 første response meldinger (mottatt og kvittering)
             VentPaSvar(2, 10);
@@ -112,7 +112,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             MottatMeldingArgsList.Clear();
             
             // Send oppdater melding
-            var arkivmeldingOppdaterMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOppdater, arkivmeldingOppdateringSerialized, "arkivmelding.xml", null, testSessionId);
+            var arkivmeldingOppdaterMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOppdater, arkivmeldingOppdateringSerialized, null, testSessionId);
 
             // Vent på 2 respons meldinger. Mottat og kvittering 
             VentPaSvar(2, 10);
@@ -145,7 +145,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             MottatMeldingArgsList.Clear();
             
             // Send hent melding
-            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentAsString, "arkivmelding.xml", null, testSessionId);
+            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentAsString, null, testSessionId);
 
             // Vent på 1 respons meldinger 
             VentPaSvar(1, 10);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/ArkivmeldingOppdatering/OppdaterOgHentMappeTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/ArkivmeldingOppdatering/OppdaterOgHentMappeTests.cs
@@ -64,7 +64,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             validator.Validate(nySaksmappeAsSerialized);
 
             // Send melding
-            var nySaksmappeMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nySaksmappeAsSerialized, "arkivmelding.xml", null, testSessionId);
+            var nySaksmappeMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nySaksmappeAsSerialized, null, testSessionId);
             
             // Vent på 2 første response meldinger (mottatt og kvittering)
             VentPaSvar(2, 10);
@@ -98,7 +98,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             MottatMeldingArgsList.Clear();
             
             // Send oppdater melding
-            var arkivmeldingOppdaterMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOppdater, arkivmeldingOppdateringSerialized, "arkivmelding.xml", null, testSessionId);
+            var arkivmeldingOppdaterMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOppdater, arkivmeldingOppdateringSerialized, null, testSessionId);
 
             // Vent på 2 respons meldinger. Mottat og kvittering 
             VentPaSvar(2, 10);
@@ -130,7 +130,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             MottatMeldingArgsList.Clear();
             
             // Send hent melding
-            var mappeHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.MappeHent, mappeHentSerialized, "arkivmelding.xml", null, testSessionId);
+            var mappeHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.MappeHent, mappeHentSerialized, null, testSessionId);
 
             // Vent på 1 respons meldinger 
             VentPaSvar(1, 10);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Feilmelding/FeilmeldingTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Feilmelding/FeilmeldingTests.cs
@@ -9,6 +9,7 @@ using KS.Fiks.Arkiv.Models.V1.Meldingstyper;
 using KS.Fiks.Arkiv.Models.V1.Metadatakatalog;
 using KS.Fiks.IO.Client;
 using KS.Fiks.IO.Client.Models;
+using KS.Fiks.IO.Send.Client.Models;
 using KS.FiksProtokollValidator.Tests.IntegrationTests.Helpers;
 using KS.FiksProtokollValidator.Tests.IntegrationTests.Validation;
 using Microsoft.Extensions.Configuration;
@@ -66,7 +67,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Feilmelding
             MottatMeldingArgsList.Clear();
             
             // Send hent melding
-            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentSerialized, "arkivmelding.xml", null, testSessionId);
+            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentSerialized, null, testSessionId);
 
             // Vent på 1 respons meldinger 
             VentPaSvar(1, 10);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Innsyn/JournalpostHentTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Innsyn/JournalpostHentTests.cs
@@ -56,7 +56,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.InnsynTests
             //File.WriteAllText("ArkivmeldingMedNyJournalpost.xml", nyJournalpostSerialized);
 
             // Send arkiver melding
-            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, "arkivmelding.xml", null, testSessionId);
+            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, null, testSessionId);
             
             // Vent på 2 første response meldinger (mottatt og kvittering)
             VentPaSvar(2, 10);
@@ -95,7 +95,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.InnsynTests
             MottatMeldingArgsList.Clear();
             
             // Send hent melding
-            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentSerialized, "arkivmelding.xml", null, testSessionId);
+            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentSerialized, null, testSessionId);
 
             // Vent på 1 respons meldinger 
             VentPaSvar(1, 10);
@@ -153,7 +153,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.InnsynTests
             //File.WriteAllText("ArkivmeldingMedNyJournalpostEksternNoekkel.xml", nyJournalpostSerialized);
 
             // Send arkivering melding
-            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, "arkivmelding.xml", null, testSessionId);
+            var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett, nyJournalpostSerialized, null, testSessionId);
             
             // Vent på 2 første response meldinger (mottatt og kvittering)
             VentPaSvar(2, 10);
@@ -192,7 +192,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.InnsynTests
             MottatMeldingArgsList.Clear();
             
             // Send hent melding
-            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentSerialized, "arkivmelding.xml", null, testSessionId);
+            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentSerialized, null, testSessionId);
 
             // Vent på 1 respons meldinger 
             VentPaSvar(1, 10);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
@@ -160,7 +160,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
             MottatMeldingArgsList.Clear();
             
             // Send hent melding
-            var mappeHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.MappeHent, mappeHentSerialized, "arkivmelding.xml", null, testSessionId);
+            var mappeHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.MappeHent, mappeHentSerialized, null, testSessionId);
 
             // Vent på 1 respons meldinger 
             VentPaSvar(1, 10);
@@ -203,7 +203,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
 
             // Send melding
             var nySaksmappeMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett,
-                nySaksmappeSerialized, "arkivmelding.xml", null, testSessionId);
+                nySaksmappeSerialized, null, testSessionId);
 
             // Vent på 2 første response meldinger (mottatt og kvittering)
             VentPaSvar(2, 10);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Sok/SokJournalpostTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Sok/SokJournalpostTests.cs
@@ -100,7 +100,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Sok
             // Send søk melding
             var sokSerialized = SerializeHelper.Serialize(sok);
             var sokMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.Sok,
-                sokSerialized, "sok.xml", null, testSessionId);
+                sokSerialized, null, testSessionId);
             
             // Vent på respons
             VentPaSvar(1, 10);
@@ -146,7 +146,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Sok
 
             // Send arkiver melding
             var nyJournalpostMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.ArkivmeldingOpprett,
-                nyJournalpostSerialized, "arkivmelding.xml", null, testSessionId);
+                nyJournalpostSerialized, null, testSessionId);
 
             Console.Out.WriteLineAsync($"Arkivmelding med ny journalpost med tittel {tittel} sendt");
 


### PR DESCRIPTION
The filename for messages are now retrieved from the `FiksArkivPayloadHelper.GetPayloadFilnavn` by default. The caller may override this for a given test by specifying it explicitly, but in most cases this should be handled from that helper.

---

The reason I added this was that I noticed that the filename was wrong in [FeilmeldingTests](https://github.com/ks-no/fiks-arkiv-integration-tests-dotnet/blob/f2f8f5a25b256941f2eae90fbfe731eb374f81bf/KS.Fiks.Arkiv.Integration.Tests/Tests/Feilmelding/FeilmeldingTests.cs#L69).