### PR TITLE
Add certificate fallback for ASIC-E

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Den nye filen skal man da putte inn sine konfigurasjonsdetaljer for Fiks-Protoko
 #### Forklaring
 `TestConfig:ArkivAccountId`: Fiks Protokoll kontoen for arkivet som skal motta meldingene.
 
+For å forenkle test-oppsett kan man la være å oppgi `AsiceSigningPublicKey` og
+`AsiceSigningPrivateKey` hvor den da vil forsøke å benytte sertifikatet oppgitt
+for MaskinPorten. Merk at dette ikke er anbefalt i produksjon.
+
 
 ### Test oppsett
 Hver test sender inn en unik id som header på Fiks-IO meldingen med navnet **testSessionId**. Dette er kun for at vår arkiv-simulator skal kunne se hvilke meldinger som hører sammen når man kjører disse testene mot simulatoren. Hvis man kjører disse testene mot en arkiv implementasjon kan arkivet ignorere denne id'en. Den er kun for intern validering av integrasjonstestene.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ I prosjektet ligger det en appsettings.json. Kopier denne og gi den nye filen na
 Den nye filen skal man da putte inn sine konfigurasjonsdetaljer for Fiks-Protokoller/Fiks-IO.  
 
 ```json
+
 {
   "TestConfig": {
-    "ArkivAccountId" : "RECEIVING_ACCOUNT_GUID_IN_FIKSIO_HERE"
+    "ArkivAccountId" : "RECEIVING_ACCOUNT_GUID_IN_FIKSIO_HERE",
+    "FagsystemName" : ""
   },
   "FiksIOConfig": {
     "ApiHost": "api.fiks.test.ks.no",
@@ -37,7 +39,9 @@ Den nye filen skal man da putte inn sine konfigurasjonsdetaljer for Fiks-Protoko
     "MaskinPortenCompanyCertificatePath": "PATH\\TO\\MASKINPORTENCERT.p12",
     "MaskinPortenCompanyCertificatePassword": "PASSWORD_FOR_MASKINPORTENCERT",
     "MaskinPortenIssuer": "dummyIssuer",
-    "MaskinPortenTokenUrl": "https://test.maskinporten.no/token"
+    "MaskinPortenTokenUrl": "https://oidc-ver2.difi.no/idporten-oidc-provider/token",
+    "AsiceSigningPrivateKey": "PATH\\TO\\SIGNING_PRIVATEKEY.PEM",
+    "AsiceSigningPublicKey": "PATH\\TO\\SIGNING_PUBLICKEY.PEM"
   }
 }
 ```


### PR DESCRIPTION
During testing, the signing is not too important. To ease the testing-setup, I added a fallback which reuses the certificate used with maskinporten.

I added a note on this in the readme, noting that it is not recommended for production.

I also added some missing entries from the `appsettings.json`-file from the readme.