### PR TITLE
Fix test opprett saksmappe og journalpost i en melding

### DIFF
--- a/KS.Fiks.Arkiv.Integration.Tests.Library/JournalpostBuilder.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests.Library/JournalpostBuilder.cs
@@ -45,9 +45,15 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Library
             return this;
         }
 
-        public Journalpost Build()
+        public Journalpost Build(
+            string? saksbehandlerNavn = null,
+            string? fagsystem = null
+            )
         {
-            var jp = CreateJournalpost();
+            var jp = CreateJournalpost(
+                saksbehandlerNavn: saksbehandlerNavn,
+                fagsystem: fagsystem
+                );
             jp.Dokumentbeskrivelse.Add(_dokumentbeskrivelse);
             if (_arkivdel != null)
             {
@@ -97,7 +103,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Library
             return dokumentbeskrivelse;
         }
 
-        private Journalpost CreateJournalpost()
+        private Journalpost CreateJournalpost(
+            string? saksbehandlerNavn = null,
+            string? fagsystem = null
+            )
         {
             return new Journalpost()
             {
@@ -105,7 +114,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Library
                 ArkivertAv = "En brukerid",
                 ReferanseEksternNoekkel = new EksternNoekkel()
                 {
-                    Fagsystem = FagsystemDefault,
+                    Fagsystem = fagsystem ?? FagsystemDefault,
                     Noekkel = Guid.NewGuid().ToString()
                 },
                 Tittel = "Internt notat",
@@ -123,7 +132,8 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Library
                             Navn = "Oppmålingsetaten",
                         },
                         Saksbehandler = new Saksbehandler() { 
-                            Navn = "Ingrid Mottaker"
+                            
+                            Navn = saksbehandlerNavn ?? "Ingrid Mottaker"
                         }
                     }
                 },

--- a/KS.Fiks.Arkiv.Integration.Tests.Library/MeldingGenerator.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests.Library/MeldingGenerator.cs
@@ -22,13 +22,20 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Library
             };
         }
 
-        public static Arkivmelding CreateArkivmeldingMedNyJournalpost(string fagsystem, string tittel = null)
+        public static Arkivmelding CreateArkivmeldingMedNyJournalpost(
+            string fagsystem, 
+            string? tittel = null,
+            string? saksbehandlerNavn = null
+            )
          {
              var arkivmelding = new Arkivmelding()
              {
                  System = fagsystem,
                  AntallFiler = 1,
-                 Registrering = JournalpostBuilder.Init().WithArkivdel(JournalpostBuilder.ArkivdelDefault).WithTittel(tittel).Build(),
+                 Registrering = JournalpostBuilder.Init().WithArkivdel(JournalpostBuilder.ArkivdelDefault).WithTittel(tittel).Build(
+                     fagsystem: fagsystem,
+                     saksbehandlerNavn: saksbehandlerNavn
+                     ),
              };
              
              return arkivmelding;

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostMedRegelTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostMedRegelTests.cs
@@ -82,7 +82,9 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
                 .Init()
                 .WithTittel("Test tittel")
                 .WithReferanseTilForelderMappe(referanseTilSaksmappe)
-                .Build();
+                .Build(
+                    fagsystem: FagsystemNavn,
+                    saksbehandlerNavn: SaksbehandlerNavn);
             
             journalpost.ReferanseEksternNoekkel = referanseEksternNoekkelNyJournalpost;
             

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostMedRegelTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostMedRegelTests.cs
@@ -30,12 +30,8 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             await Init();
             
             validator = new SimpleXsdValidator();
-            
-            _saksmappeEksternNoekkel = new EksternNoekkel()
-            {
-                Fagsystem = FagsystemNavn,
-                Noekkel = SaksmappeEksternNoekkelNoekkel
-            };
+
+            _saksmappeEksternNoekkel = GenererEksternNoekkel(SaksmappeEksternNoekkelNoekkel);
         }
         
         /*
@@ -57,12 +53,8 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
              * Med klassifikasjon
              */
 
-            var klassifikasjon = new Klassifikasjon()
-            {
-                KlasseID = "En klasseID",
-            };
             
-            var mappe = MappeBuilder.Init().WithKlassifikasjon(klassifikasjon).BuildSaksmappe(_saksmappeEksternNoekkel);
+            var mappe = MappeBuilder.Init().WithKlassifikasjon(GenererKlassifikasjon()).BuildSaksmappe(_saksmappeEksternNoekkel);
             var referanseTilSaksmappe = new ReferanseTilMappe()
             {
                 ReferanseEksternNoekkel = _saksmappeEksternNoekkel
@@ -70,12 +62,8 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             
             MottattMeldingArgs? arkivmeldingKvitteringMelding;
             PayloadFile arkivmeldingKvitteringPayload;
-            
-            var referanseEksternNoekkelNyJournalpost= new EksternNoekkel()
-            {
-                Fagsystem = FagsystemNavn,
-                Noekkel = Guid.NewGuid().ToString()
-            };
+
+            var referanseEksternNoekkelNyJournalpost = GenererEksternNoekkel();
 
             // Legg til journalpost i arkivmelding
             var journalpost = JournalpostBuilder

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostTests.cs
@@ -28,12 +28,8 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             await Init();
             
             validator = new SimpleXsdValidator();
-            
-            _saksmappeEksternNoekkel = new EksternNoekkel()
-            {
-                Fagsystem = FagsystemNavn,
-                Noekkel = SaksmappeEksternNoekkelNoekkel
-            };
+
+            _saksmappeEksternNoekkel = GenererEksternNoekkel(SaksmappeEksternNoekkelNoekkel);
         }
         
         /*
@@ -54,12 +50,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
              * Med klassifikasjon
              */
 
-            var klassifikasjon = new Klassifikasjon()
-            {
-                KlasseID = "En klasseID",
-            };
-            
-            var mappe = MappeBuilder.Init().WithKlassifikasjon(klassifikasjon).BuildSaksmappe(_saksmappeEksternNoekkel);
+            var mappe = MappeBuilder.Init().WithKlassifikasjon(GenererKlassifikasjon()).BuildSaksmappe(_saksmappeEksternNoekkel);
             var referanseTilSaksmappe = new ReferanseTilMappe()
             {
                 ReferanseEksternNoekkel = _saksmappeEksternNoekkel
@@ -67,12 +58,8 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             
             MottattMeldingArgs? arkivmeldingKvitteringMelding;
             PayloadFile arkivmeldingKvitteringPayload;
-            
-            var referanseEksternNoekkelNyJournalpost= new EksternNoekkel()
-            {
-                Fagsystem = FagsystemNavn,
-                Noekkel = Guid.NewGuid().ToString()
-            };
+
+            var referanseEksternNoekkelNyJournalpost = GenererEksternNoekkel();
 
             // Legg til journalpost i arkivmelding
             var journalpost = JournalpostBuilder
@@ -190,12 +177,8 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             
             MottattMeldingArgs? arkivmeldingKvitteringMelding;
             PayloadFile arkivmeldingKvitteringPayload;
-            
-            var referanseEksternNoekkelNyJournalpost= new EksternNoekkel()
-            {
-                Fagsystem = FagsystemNavn,
-                Noekkel = Guid.NewGuid().ToString()
-            };
+
+            var referanseEksternNoekkelNyJournalpost = GenererEksternNoekkel();
 
             var referanseForelderMappe = new ReferanseTilMappe()
             {
@@ -315,12 +298,8 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             
             MottattMeldingArgs? arkivmeldingKvitteringMelding;
             PayloadFile arkivmeldingKvitteringPayload;
-            
-            var referanseEksternNoekkelNyJournalpost= new EksternNoekkel()
-            {
-                Fagsystem = FagsystemNavn,
-                Noekkel = Guid.NewGuid().ToString()
-            };
+
+            var referanseEksternNoekkelNyJournalpost = GenererEksternNoekkel();
 
             var referanseForelderMappe = new ReferanseTilMappe()
             {

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostTests.cs
@@ -79,7 +79,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
                 .Init()
                 .WithTittel("Test tittel")
                 .WithReferanseTilForelderMappe(referanseTilSaksmappe)
-                .Build();
+                .Build(
+                    fagsystem: FagsystemNavn,
+                    saksbehandlerNavn: SaksbehandlerNavn
+                    );
             journalpost.ReferanseEksternNoekkel = referanseEksternNoekkelNyJournalpost;
             var arkivmelding = MeldingGenerator.CreateArkivmelding(FagsystemNavn);
             arkivmelding.Registrering = journalpost;
@@ -203,7 +206,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
                 .Init()
                 .WithTittel("Test")
                 .WithReferanseTilForelderMappe(referanseForelderMappe)
-                .Build();
+                .Build(
+                    fagsystem: FagsystemNavn,
+                    saksbehandlerNavn: SaksbehandlerNavn
+                    );
             journalpost.ReferanseEksternNoekkel = referanseEksternNoekkelNyJournalpost;
             var arkivmelding = MeldingGenerator.CreateArkivmelding(FagsystemNavn);
             arkivmelding.Registrering = journalpost;
@@ -324,7 +330,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             var journalpost = JournalpostBuilder.Init()
                 .WithTittel("Test tittel")
                 .WithReferanseTilForelderMappe(referanseForelderMappe)
-                .Build();
+                .Build(
+                    fagsystem: FagsystemNavn,
+                    saksbehandlerNavn: SaksbehandlerNavn
+                    );
             journalpost.ReferanseEksternNoekkel = referanseEksternNoekkelNyJournalpost;
             var arkivmelding = MeldingGenerator.CreateArkivmelding(FagsystemNavn);
             arkivmelding.Registrering = journalpost;

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
@@ -30,6 +30,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
         protected FiksRequestMessageService? FiksRequestService;
         protected Guid MottakerKontoId;
         protected string FagsystemNavn;
+        protected string SaksbehandlerNavn;
         protected SimpleXsdValidator validator;
 
         protected async Task Init()
@@ -44,6 +45,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
             FiksRequestService = new FiksRequestMessageService(config);
             MottakerKontoId = Guid.Parse(config["TestConfig:ArkivAccountId"]);
             FagsystemNavn = config["TestConfig:FagsystemName"];
+            SaksbehandlerNavn = config["TestConfig:SaksbehandlerName"] ;
         }
         
         protected static void VentPaSvar(int antallForventet, int antallVenter)

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
@@ -78,9 +78,9 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
                         throw new UnexpectedAnswerException($"Uforventet feilmelding mottatt {mottatMeldingArgs.Melding.MeldingType}. Feilmelding: {feilmelding.Feilmelding}. Forventet meldingstypen {forventetMeldingstype}");
                     }
 
-                    var feilmeldingerString = string.Join("\n",
+                    var feilmeldingerString = string.Join(Environment.NewLine,
                         feilmeldinger.Select(m => HentUtFeilMelding(m).Feilmelding));
-                    throw new UnexpectedAnswerException($"Uforventet melding mottatt av typen {mottatMeldingArgs.Melding.MeldingType}. Forventet meldingstypen {forventetMeldingstype}. Feilmeldinger: {feilmeldingerString}");  
+                    throw new UnexpectedAnswerException($"Uforventet melding mottatt av typen {mottatMeldingArgs.Melding.MeldingType}. Forventet meldingstypen {forventetMeldingstype}.{Environment.NewLine} Feilmeldinger: {feilmeldinger.Count}{Environment.NewLine}{Environment.NewLine}{Environment.NewLine} {feilmeldingerString}");  
                 }
             }
             Console.Out.WriteLineAsync($"Forventet meldingstype {forventetMeldingstype} mottatt for meldingsid  {sendtMeldingsid}!");

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,32 +19,50 @@ using KS.FiksProtokollValidator.Tests.IntegrationTests.Helpers;
 using KS.FiksProtokollValidator.Tests.IntegrationTests.Validation;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
+using Klassifikasjon = KS.Fiks.Arkiv.Models.V1.Arkivering.Arkivmelding.Klassifikasjon;
 
 namespace KS.Fiks.Arkiv.Integration.Tests.Tests
 {
     public class IntegrationTestsBase
     {
         protected static List<MottattMeldingArgs>? MottatMeldingArgsList;
+        protected static IConfigurationRoot config;
         protected IFiksIOClient? Client;
         protected FiksRequestMessageService? FiksRequestService;
         protected Guid MottakerKontoId;
-        protected string FagsystemNavn;
-        protected string SaksbehandlerNavn;
+        protected static string FagsystemNavn;
+        protected static string SaksbehandlerNavn;
+        protected static string KlassifikasjonKlasseID;
+        protected static string KlassifikasjonssystemID;
         protected SimpleXsdValidator validator;
 
         protected async Task Init()
         {
             //TODO En annen lokal lagring som kjørte for disse testene hadde vært stilig i stedet for en liste.
             MottatMeldingArgsList = new List<MottattMeldingArgs>();
-            var config = new ConfigurationBuilder()
+            config = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.Local.json")
                 .Build();
             Client = await FiksIOClient.CreateAsync(FiksIOConfigurationBuilder.CreateFiksIOConfiguration(config));
             Client.NewSubscription(OnMottattMelding);
             FiksRequestService = new FiksRequestMessageService(config);
-            MottakerKontoId = Guid.Parse(config["TestConfig:ArkivAccountId"]);
-            FagsystemNavn = config["TestConfig:FagsystemName"];
-            SaksbehandlerNavn = config["TestConfig:SaksbehandlerName"] ;
+            MottakerKontoId = Guid.Parse(GetTestConfig("ArkivAccountId"));
+            FagsystemNavn = GetTestConfig("FagsystemName");
+            SaksbehandlerNavn = GetTestConfig("SaksbehandlerName");
+            KlassifikasjonKlasseID = GetRequiredTestConfig("KlassifikasjonKlasseID") ;
+            KlassifikasjonssystemID = GetRequiredTestConfig("KlassifikasjonssystemID") ;
+        }
+        
+        private string GetTestConfig(string key) => config[$"TestConfig:{key}"] ;
+
+        private string GetRequiredTestConfig(string key)
+        {
+            var value = GetTestConfig(key);
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new ArgumentException($"The config-key '{key}' is required. See you config-file ({string.Join(", ",config.Providers.OfType<FileConfigurationProvider>().Select(p => p.Source.Path) )})");
+            }
+            return value;
         }
         
         protected static void VentPaSvar(int antallForventet, int antallVenter)
@@ -245,5 +262,16 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
                 SerializeHelper.DeserializeXml<ArkivmeldingKvittering>(arkivmeldingKvitteringPayload.PayloadAsString);
             return arkivmeldingKvittering;
         }
+        
+        protected static Klassifikasjon GenererKlassifikasjon() => new ()
+            {
+                KlasseID = KlassifikasjonKlasseID,
+                KlassifikasjonssystemID = KlassifikasjonssystemID
+            };
+            protected static EksternNoekkel GenererEksternNoekkel( string? noekkel = null) => new ()
+            {
+                Fagsystem = FagsystemNavn,
+                Noekkel = noekkel ?? Guid.NewGuid().ToString()
+            };
     }
 }

--- a/KS.Fiks.Arkiv.Integration.Tests/appsettings.json
+++ b/KS.Fiks.Arkiv.Integration.Tests/appsettings.json
@@ -1,7 +1,8 @@
 {
   "TestConfig": {
     "ArkivAccountId" : "RECEIVING_ACCOUNT_GUID_IN_FIKSIO_HERE",
-    "FagsystemName" : ""
+    "FagsystemName" : "Standard vagsystem-navn i ditt system",
+    "SaksbehandlerName": "Standard saksbehandler-navn i ditt system"
   },
   "FiksIOConfig": {
     "ApiHost": "api.fiks.test.ks.no",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Den nye filen skal man da putte inn sine konfigurasjonsdetaljer for Fiks-Protoko
 {
   "TestConfig": {
     "ArkivAccountId" : "RECEIVING_ACCOUNT_GUID_IN_FIKSIO_HERE",
-    "FagsystemName" : ""
+    "FagsystemName" : "Standard vagsystem-navn i ditt system",
+    "SaksbehandlerName": "Standard saksbehandler-navn i ditt system"
   },
   "FiksIOConfig": {
     "ApiHost": "api.fiks.test.ks.no",

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Den nye filen skal man da putte inn sine konfigurasjonsdetaljer for Fiks-Protoko
   "TestConfig": {
     "ArkivAccountId" : "RECEIVING_ACCOUNT_GUID_IN_FIKSIO_HERE",
     "FagsystemName" : "Standard vagsystem-navn i ditt system",
-    "SaksbehandlerName": "Standard saksbehandler-navn i ditt system"
+    "SaksbehandlerName": "Standard saksbehandler-navn i ditt system",
+    "KlassifikasjonKlasseID": "001",
+    "KlassifikasjonssystemID": "EMNE"
   },
   "FiksIOConfig": {
     "ApiHost": "api.fiks.test.ks.no",


### PR DESCRIPTION
testen `Opprett_Saksmappe_Og_Journalpost_I_En_Melding` skal nå fungere.

Klassifikasjon og saksbehandler kommer nå fra konfig

Opprettet noen hjelpfunksjonsjoner