### PR TITLE
Testharness 

### DIFF
--- a/KS.Fiks.Arkiv.Integration.Tests.Library/JournalpostBuilder.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests.Library/JournalpostBuilder.cs
@@ -12,6 +12,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Library
         public const string ArkivdelDefault = "Arkiv validatortester";
 
         private ReferanseTilMappe _referanseTilMappe;
+        private EksternNoekkel _referanseEksternNoekkel;
         private string _tittel;
         private string _arkivdel;
         private Dokumentbeskrivelse _dokumentbeskrivelse;
@@ -21,6 +22,11 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Library
             return new JournalpostBuilder();
         }
 
+        public JournalpostBuilder WithReferanseEksternNoekkel(EksternNoekkel referanseEksternNoekkel)
+        {
+            _referanseEksternNoekkel = referanseEksternNoekkel;
+            return this;
+        }
         public JournalpostBuilder WithReferanseTilForelderMappe(ReferanseTilMappe referanseTilMappe)
         {
             _referanseTilMappe = referanseTilMappe;
@@ -60,6 +66,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Library
                 jp.Arkivdel = new Kode() {KodeProperty = _arkivdel};
             }
             jp.ReferanseForelderMappe = _referanseTilMappe;
+            jp.ReferanseEksternNoekkel = _referanseEksternNoekkel;
             jp.Tittel = _tittel;
             return jp;
         }

--- a/KS.Fiks.Arkiv.Integration.Tests.Library/MeldingGenerator.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests.Library/MeldingGenerator.cs
@@ -40,14 +40,22 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Library
              
              return arkivmelding;
          }
-        
-        public static Arkivmelding CreateArkivmelding(string fagsystem)
+
+        public static Arkivmelding CreateArkivmelding(string fagsystem, Journalpost? journalpost = null, Mappe? mappe = null)
         {
             var arkivmelding = new Arkivmelding()
             {
                 System = fagsystem,
                 AntallFiler = 1,
             };
+            if (journalpost != null)
+            {
+                arkivmelding.Registrering = journalpost;
+            }
+            if (mappe != null)
+            {
+                arkivmelding.Mappe = mappe;
+            }
              
             return arkivmelding;
         }

--- a/KS.Fiks.Arkiv.Integration.Tests/FiksIO/FiksRequestMessageService.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/FiksIO/FiksRequestMessageService.cs
@@ -34,7 +34,7 @@ using OnSendCallback = Action<Guid, Guid,  string>;
             {
                 AddOnSendCallback((s, m, t) =>
                 {
-                    Console.Out.WriteLine($"{Environment.NewLine}-> Sendte {MeldingHelper.ShortenMessageType(t)}-melding med id {m} til {s} ");
+                    Console.Out.WriteLine($"{Environment.NewLine}📡 Sendte {MeldingHelper.ShortenMessageType(t)}-melding med id {m} til {s} ");
                 });
                 
             }

--- a/KS.Fiks.Arkiv.Integration.Tests/FiksIO/FiksRequestMessageService.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/FiksIO/FiksRequestMessageService.cs
@@ -52,7 +52,7 @@ using OnSendCallback = Action<Guid, Guid,  string>;
         
         private Task Initialization { get; set; }
 
-        public async Task<Guid> Send(Guid mottakerKontoId, string meldingsType, string payloadContent, List<KeyValuePair<string, FileStream>>? attachments, string testSessionId, string payloadFilename = null)
+        public async Task<Guid> Send(Guid mottakerKontoId, string meldingsType, string payloadContent, List<KeyValuePair<string, FileStream>>? attachments, string testSessionId, string? payloadFilename = null)
         {
             var stackTrace = new StackTrace();
             await Initialization;

--- a/KS.Fiks.Arkiv.Integration.Tests/Helpers/MeldingHelper.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Helpers/MeldingHelper.cs
@@ -35,7 +35,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Helpers
                         {
                             var streamReader = new StreamReader(entryStream);
                             var xml = streamReader.ReadToEndAsync().Result;
-                            payloadFiles.Add(new PayloadFile(asiceReadEntry.FileName, xml ));
+                            payloadFiles.Add(new PayloadFile(asiceReadEntry.FileName, xml));
                         }
                     }
                 }
@@ -47,6 +47,17 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Helpers
             }
 
             return payloadFiles;
+        }
+
+        public static string ShortenMessageType(MottattMeldingArgs mottattMeldingArgs) => 
+            ShortenMessageType(mottattMeldingArgs.Melding.MeldingType);
+        public static string ShortenMessageType(string MeldingType)
+        {
+
+            var last = MeldingType.LastIndexOf('.');
+            return last >= 0
+                ? MeldingType.Substring(last + 1)
+                : MeldingType;
         }
 
     }

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostMedRegelTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Arkivering/OpprettSaksmappeOgJournalpostMedRegelTests.cs
@@ -97,10 +97,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
 
             // Verifiser at man får mottatt melding
-            SjekkForventetMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
+            SjekkForventetMelding(nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
 
             // Verifiser at man får arkivmeldingKvittering melding
-            SjekkForventetMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
+            SjekkForventetMelding(nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
             
             // Hent meldingen
             arkivmeldingKvitteringMelding = GetMottattMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
@@ -135,7 +135,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Arkivering
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
             
             // Verifiser at man får RegistreringHentResultat melding
-            SjekkForventetMelding(MottatMeldingArgsList, journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);
+            SjekkForventetMelding(journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);
             
             // Hent meldingen
             var registreringHentResultatMelding = GetMottattMelding(MottatMeldingArgsList, journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/ArkivmeldingOppdatering/OppdaterOgHentJournalpostTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/ArkivmeldingOppdatering/OppdaterOgHentJournalpostTests.cs
@@ -65,10 +65,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
 
             // Verifiser at man får mottatt melding
-            SjekkForventetMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
+            SjekkForventetMelding(nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
 
             // Verifiser at man får arkivmeldingKvittering melding
-            SjekkForventetMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
+            SjekkForventetMelding(nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
             
             // Hent melding
             var arkivmeldingKvitteringMelding = GetMottattMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
@@ -111,10 +111,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
 
             // Verifiser at man får mottatt melding på oppdatering
-            SjekkForventetMelding(MottatMeldingArgsList, arkivmeldingOppdaterMeldingId, FiksArkivMeldingtype.ArkivmeldingOppdaterMottatt);
+            SjekkForventetMelding(arkivmeldingOppdaterMeldingId, FiksArkivMeldingtype.ArkivmeldingOppdaterMottatt);
 
             // Verifiser at man får arkivmeldingOppdaterKvittering melding
-            SjekkForventetMelding(MottatMeldingArgsList, arkivmeldingOppdaterMeldingId, FiksArkivMeldingtype.ArkivmeldingOppdaterKvittering);
+            SjekkForventetMelding(arkivmeldingOppdaterMeldingId, FiksArkivMeldingtype.ArkivmeldingOppdaterKvittering);
             
             //Hent melding
             var arkivmeldingOppdaterKvittering = GetMottattMelding(MottatMeldingArgsList, arkivmeldingOppdaterMeldingId, FiksArkivMeldingtype.ArkivmeldingOppdaterKvittering);
@@ -145,7 +145,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
             
             // Verifiser at man får journalpostHentResultat melding
-            SjekkForventetMelding(MottatMeldingArgsList, journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);
+            SjekkForventetMelding(journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);
             
             // Hent melding
             var journalpostHentResultatMelding = GetMottattMelding(MottatMeldingArgsList, journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/ArkivmeldingOppdatering/OppdaterOgHentMappeTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/ArkivmeldingOppdatering/OppdaterOgHentMappeTests.cs
@@ -63,10 +63,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
 
             // Verifiser at man får mottatt melding
-            SjekkForventetMelding(MottatMeldingArgsList, nySaksmappeMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
+            SjekkForventetMelding(nySaksmappeMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
 
             // Verifiser at man får arkivmeldingKvittering melding
-            SjekkForventetMelding(MottatMeldingArgsList, nySaksmappeMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
+            SjekkForventetMelding(nySaksmappeMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
             
             // Hent meldingen
             var arkivmeldingKvitteringMelding = GetMottattMelding(MottatMeldingArgsList, nySaksmappeMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
@@ -97,10 +97,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
             
             // Verifiser at man får mottatt melding
-            SjekkForventetMelding(MottatMeldingArgsList, arkivmeldingOppdaterMeldingId, FiksArkivMeldingtype.ArkivmeldingOppdaterMottatt);
+            SjekkForventetMelding(arkivmeldingOppdaterMeldingId, FiksArkivMeldingtype.ArkivmeldingOppdaterMottatt);
 
             // Verifiser at man får arkivmeldingOppdaterKvittering melding
-            SjekkForventetMelding(MottatMeldingArgsList, arkivmeldingOppdaterMeldingId, FiksArkivMeldingtype.ArkivmeldingOppdaterKvittering);
+            SjekkForventetMelding(arkivmeldingOppdaterMeldingId, FiksArkivMeldingtype.ArkivmeldingOppdaterKvittering);
             
             // Hent melding
             var arkivmeldingOppdaterKvittering = GetMottattMelding(MottatMeldingArgsList, arkivmeldingOppdaterMeldingId, FiksArkivMeldingtype.ArkivmeldingOppdaterKvittering);
@@ -130,7 +130,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.ArkivmeldingOppdatering
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
             
             // Verifiser at man får mappeHentResultat melding
-            SjekkForventetMelding(MottatMeldingArgsList, mappeHentMeldingId, FiksArkivMeldingtype.MappeHentResultat);
+            SjekkForventetMelding(mappeHentMeldingId, FiksArkivMeldingtype.MappeHentResultat);
             
             // Hent melding
             var mappeHentResultatMelding = GetMottattMelding(MottatMeldingArgsList, mappeHentMeldingId, FiksArkivMeldingtype.MappeHentResultat);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Feilmelding/FeilmeldingTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Feilmelding/FeilmeldingTests.cs
@@ -28,48 +28,16 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Feilmelding
             await Init();
         }
 
-        [Test] 
+        [Test]
         public async Task Hent_Journalpost_Med_Ikke_Eksisterende_EksternNoekkel_Returnerer_Ikkefunnet()
         {
-            // Denne id'en gjør at Arkiv-simulatoren ser hvilke meldinger som henger sammen. Har ingen funksjon ellers. 
-            var testSessionId = Guid.NewGuid().ToString();
-            var validator = new SimpleXsdValidator();
-            
-            var referanseEksternNoekkelIkkeGyldig = new EksternNoekkel()
-            {
-                Fagsystem = FagsystemNavn,
-                Noekkel = Guid.Empty.ToString() // Bør ikke kunne eksistere i Arkivet
-            };
-            
-            /*
-             * STEG 1:
-             * Forsøk å hente journalpost som ikke skal eksistere
-             */
-            var journalpostHent = RegistreringHentBuilder.Init().WithEksternNoekkel(referanseEksternNoekkelIkkeGyldig).Build();
-            
-            var journalpostHentSerialized = SerializeHelper.Serialize(journalpostHent);
-            
-            // Valider innhold (xml)
-            validator.Validate(journalpostHentSerialized);
-            
-            // Utkommenter dette hvis man vil å skrive til fil for å sjekke resultat manuelt
-            //File.WriteAllText("HentJournalpostEksternNoekkelIkkeGyldig.xml", journalpostHentSerialized);
-            
-            // Nullstill meldingsliste
-            MottatMeldingArgsList.Clear();
-            
-            // Send hent melding
-            var journalpostHentMeldingId = await FiksRequestService.Send(MottakerKontoId, FiksArkivMeldingtype.RegistreringHent, journalpostHentSerialized, null, testSessionId);
-
-            // Vent på 1 respons meldinger 
-            VentPaSvar(1, 10);
-
-            Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
-            
-            // Verifiser at man får en Ikkefunnet feil-melding
-            var ikkefunnetFeilmelding = GetMottattMelding(MottatMeldingArgsList, journalpostHentMeldingId, FiksArkivMeldingtype.Ikkefunnet);
-
-            Assert.IsNotNull(ikkefunnetFeilmelding);
+            var journalpostHent = RegistreringHentBuilder
+                .Init()
+                .WithEksternNoekkel(GenererEksternNoekkel(Guid.Empty.ToString())) // Denne burde ikke eksistere i systemet
+                .Build();
+            new TestHarness( this, FiksArkivMeldingtype.RegistreringHent, journalpostHent )
+                .Send()
+                .ExpectToFail(FiksArkivMeldingtype.Ikkefunnet);
         }
     }
 }

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Innsyn/JournalpostHentTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Innsyn/JournalpostHentTests.cs
@@ -54,10 +54,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.InnsynTests
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
 
             // Verifiser at man får mottatt melding
-            SjekkForventetMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
+            SjekkForventetMelding(nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
 
             // Verifiser at man får arkivmeldingKvittering melding
-            SjekkForventetMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
+            SjekkForventetMelding(nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
             
             // Hent melding
             var arkivmeldingKvitteringMelding = GetMottattMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
@@ -94,7 +94,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.InnsynTests
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
             
             // Verifiser at man får journalpostHentResultat melding
-            SjekkForventetMelding(MottatMeldingArgsList, journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);
+            SjekkForventetMelding(journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);
             
             // Hent melding
             var journalpostHentResultatMelding = GetMottattMelding(MottatMeldingArgsList, journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);
@@ -151,10 +151,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.InnsynTests
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
 
             // Verifiser at man får mottatt melding
-            SjekkForventetMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
+            SjekkForventetMelding(nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
 
             // Verifiser at man får arkivmeldingKvittering melding
-            SjekkForventetMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
+            SjekkForventetMelding(nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
             
             // Hent melding
             var arkivmeldingKvitteringMelding = GetMottattMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
@@ -191,7 +191,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.InnsynTests
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
             
             // Verifiser at man får journalpostHentResultat melding
-            SjekkForventetMelding(MottatMeldingArgsList, journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);
+            SjekkForventetMelding(journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);
             
             // Hent melding
             var journalpostHentResultatMelding = GetMottattMelding(MottatMeldingArgsList, journalpostHentMeldingId, FiksArkivMeldingtype.RegistreringHentResultat);

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
@@ -25,27 +25,35 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
 {
     public class IntegrationTestsBase
     {
-        protected static List<MottattMeldingArgs>? MottatMeldingArgsList;
-        protected static IConfigurationRoot config;
-        protected IFiksIOClient? Client;
-        protected FiksRequestMessageService? FiksRequestService;
-        protected Guid MottakerKontoId;
-        protected static string FagsystemNavn;
-        protected static string SaksbehandlerNavn;
-        protected static string KlassifikasjonKlasseID;
-        protected static string KlassifikasjonssystemID;
-        protected SimpleXsdValidator validator;
+        public List<MottattMeldingArgs>? MottatMeldingArgsList;
+        public string TestSessionId;
+        public static IConfigurationRoot config;
+        public IFiksIOClient? Client;
+        public FiksRequestMessageService? FiksRequestService;
+        public Guid MottakerKontoId;
+        public static string FagsystemNavn;
+        public static string SaksbehandlerNavn;
+        public static string KlassifikasjonKlasseID;
+        public static string KlassifikasjonssystemID;
+        public SimpleXsdValidator validator;
+        public Action<object, MottattMeldingArgs>? onMottatMelding;
 
         protected async Task Init()
         {
             //TODO En annen lokal lagring som kjørte for disse testene hadde vært stilig i stedet for en liste.
+            await ConfInit();
+            MottatMeldingArgsList = new List<MottattMeldingArgs>();
+            Client = await FiksIOClient.CreateAsync(FiksIOConfigurationBuilder.CreateFiksIOConfiguration(config));
+            Client.NewSubscription(OnMottattMelding);
+        }
+        protected async Task ConfInit()
+        {
             MottatMeldingArgsList = new List<MottattMeldingArgs>();
             config = new ConfigurationBuilder()
                 .AddJsonFile("appsettings.Local.json")
                 .Build();
-            Client = await FiksIOClient.CreateAsync(FiksIOConfigurationBuilder.CreateFiksIOConfiguration(config));
-            Client.NewSubscription(OnMottattMelding);
             FiksRequestService = new FiksRequestMessageService(config);
+            TestSessionId = Guid.NewGuid().ToString();
             MottakerKontoId = Guid.Parse(GetTestConfig("ArkivAccountId"));
             FagsystemNavn = GetTestConfig("FagsystemName");
             SaksbehandlerNavn = GetTestConfig("SaksbehandlerName");
@@ -65,45 +73,71 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
             return value;
         }
         
-        protected static void VentPaSvar(int antallForventet, int antallVenter)
+        public void VentPaSvar(int antallForventet, int antallVenter, List<MottattMeldingArgs>? mottattMeldingArgsEnumerable = null)
         {
             var counter = 0;
-            while (MottatMeldingArgsList != null && MottatMeldingArgsList.Count <= antallForventet && counter < antallVenter)
+            if (mottattMeldingArgsEnumerable == null)
+            {
+                mottattMeldingArgsEnumerable = MottatMeldingArgsList;
+
+            }
+            while (mottattMeldingArgsEnumerable != null && mottattMeldingArgsEnumerable.Count <= antallForventet && counter < antallVenter)
             {
                 Thread.Sleep(500);
                 counter++;
             }
         }
 
-        protected static async void OnMottattMelding(object sender, MottattMeldingArgs mottattMeldingArgs)
+         async void OnMottattMelding(object sender, MottattMeldingArgs mottattMeldingArgs)
         {
-            var shortMsgType = MeldingHelper.ShortenMessageType(mottattMeldingArgs);
-            await Console.Out.WriteLineAsync($"📨 Mottatt {shortMsgType}-melding med MeldingId: {mottattMeldingArgs.Melding.MeldingId}, SvarPaMeldingId: {mottattMeldingArgs.Melding.SvarPaMelding}, MeldingType: {mottattMeldingArgs.Melding.MeldingType} og lagrer i listen");
-            MottatMeldingArgsList?.Add(mottattMeldingArgs);
+            if (onMottatMelding != null)
+            {
+                onMottatMelding(sender, mottattMeldingArgs);
+            }
+            else
+            {
+                var shortMsgType = MeldingHelper.ShortenMessageType(mottattMeldingArgs);
+                await Console.Out.WriteLineAsync($"📨 Mottatt {shortMsgType}-melding med MeldingId: {mottattMeldingArgs.Melding.MeldingId}, SvarPaMeldingId: {mottattMeldingArgs.Melding.SvarPaMelding}, MeldingType: {mottattMeldingArgs.Melding.MeldingType} og lagrer i listen");
+            }
+             MottatMeldingArgsList?.Add(mottattMeldingArgs);
             mottattMeldingArgs.SvarSender?.Ack();
         }
 
-        protected static void SjekkForventetMelding(IEnumerable<MottattMeldingArgs>? mottattMeldingArgsList, Guid sendtMeldingsid, string forventetMeldingstype)
+        public void SjekkForventetMelding(Guid sendtMeldingsid, string forventetMeldingstype, IEnumerable<MottattMeldingArgs>? mottattMeldingArgsEnumerable = null)
         {
-            var found = mottattMeldingArgsList.Where(mottattMeldingArgs => mottattMeldingArgs.Melding.SvarPaMelding == sendtMeldingsid).Any(mottatMeldingArgs => mottatMeldingArgs.Melding.MeldingType == forventetMeldingstype);
+            SjekkForventetMelding(mottattMeldingArgsEnumerable ?? MottatMeldingArgsList, sendtMeldingsid, new []{forventetMeldingstype}, 1);
+        }
+
+        public void SjekkForventetMelding(Guid sendtMeldingsid, IEnumerable<string> forventetEnAvMeldingstype,
+            int minstForventetAntall, IEnumerable<MottattMeldingArgs>? mottattMeldingArgsEnumerable = null)
+        {
+            SjekkForventetMelding(mottattMeldingArgsEnumerable, sendtMeldingsid, forventetEnAvMeldingstype, minstForventetAntall);
+        }
+        public static void SjekkForventetMelding(IEnumerable<MottattMeldingArgs>? mottattMeldingArgsList, Guid sendtMeldingsid, IEnumerable<string> forventetEnAvMeldingstype, int minstForventetAntall)
+        {
+            var found = mottattMeldingArgsList
+                .Where( mottattMeldingArgs => mottattMeldingArgs.Melding.SvarPaMelding == sendtMeldingsid)
+                .Where(mottatMeldingArgs => forventetEnAvMeldingstype.Contains(mottatMeldingArgs.Melding.MeldingType))
+                .DistinctBy(m => m.Melding.MeldingId)
+                ;
             var feilmeldinger =
                 mottattMeldingArgsList.Where(m => FiksArkivMeldingtype.IsFeilmelding(m.Melding.MeldingType)).ToList();
-            if (!found)
+            if (found.Count() < minstForventetAntall)
             {
                 foreach (var mottatMeldingArgs in mottattMeldingArgsList)
                 {
                     if (FiksArkivMeldingtype.IsFeilmelding(mottatMeldingArgs.Melding.MeldingType))
                     {
                         var feilmelding = HentUtFeilMelding(mottatMeldingArgs);
-                        throw new UnexpectedAnswerException($"Uforventet feilmelding mottatt {mottatMeldingArgs.Melding.MeldingType}. Feilmelding: {feilmelding.Feilmelding}. Forventet meldingstypen {forventetMeldingstype}");
+                        throw new UnexpectedAnswerException($"Uforventet feilmelding mottatt {mottatMeldingArgs.Melding.MeldingType}. Feilmelding: {feilmelding.Feilmelding}. Forventet meldingstypen {string.Join(",", forventetEnAvMeldingstype)}");
                     }
 
                     var feilmeldingerString = string.Join(Environment.NewLine,
                         feilmeldinger.Select(m => HentUtFeilMelding(m).Feilmelding));
-                    throw new UnexpectedAnswerException($"Uforventet melding mottatt av typen {mottatMeldingArgs.Melding.MeldingType}. Forventet meldingstypen {forventetMeldingstype}.{Environment.NewLine} Feilmeldinger: {feilmeldinger.Count}{Environment.NewLine}{Environment.NewLine}{Environment.NewLine} {feilmeldingerString}");  
+                    throw new UnexpectedAnswerException($"Uforventet melding mottatt av typen {mottatMeldingArgs.Melding.MeldingType}. Forventet meldingstypen {string.Join(", ", forventetEnAvMeldingstype)}.{Environment.NewLine} Feilmeldinger: {feilmeldinger.Count}{Environment.NewLine}{Environment.NewLine}{Environment.NewLine} {feilmeldingerString}");  
                 }
             }
-            Console.Out.WriteLineAsync($"🎉 Forventet meldingstype {forventetMeldingstype} mottatt for meldingsid  {sendtMeldingsid}!");
+            Console.Out.WriteLineAsync($"🎉 Forventet meldingstype {string.Join(", ", forventetEnAvMeldingstype)} mottatt for meldingsid  {sendtMeldingsid}!");
         }
 
         protected static FeilmeldingBase HentUtFeilMelding(MottattMeldingArgs mottatMeldingArgs)
@@ -130,7 +164,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
         }
         
 
-        protected static MottattMeldingArgs? GetMottattMelding(List<MottattMeldingArgs>? mottattMeldingArgsList, Guid sendtMeldingsid, string forventetMeldingstype)
+        public static MottattMeldingArgs? GetMottattMelding(List<MottattMeldingArgs>? mottattMeldingArgsList, Guid sendtMeldingsid, string forventetMeldingstype)
         {
             foreach (var mottatMeldingArgs in mottattMeldingArgsList)
             {
@@ -273,6 +307,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
             {
                 Fagsystem = FagsystemNavn,
                 Noekkel = noekkel ?? Guid.NewGuid().ToString()
+            };
+            protected static ReferanseTilMappe GenererReferanseTilMappe( string? noekkel = null) => new ()
+            {
+                ReferanseEksternNoekkel = GenererEksternNoekkel(noekkel)
             };
     }
 }

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
@@ -78,7 +78,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
         protected static async void OnMottattMelding(object sender, MottattMeldingArgs mottattMeldingArgs)
         {
             var shortMsgType = MeldingHelper.ShortenMessageType(mottattMeldingArgs);
-            await Console.Out.WriteLineAsync($"Mottatt {shortMsgType}-melding med MeldingId: {mottattMeldingArgs.Melding.MeldingId}, SvarPaMeldingId: {mottattMeldingArgs.Melding.SvarPaMelding}, MeldingType: {mottattMeldingArgs.Melding.MeldingType} og lagrer i listen");
+            await Console.Out.WriteLineAsync($"📨 Mottatt {shortMsgType}-melding med MeldingId: {mottattMeldingArgs.Melding.MeldingId}, SvarPaMeldingId: {mottattMeldingArgs.Melding.SvarPaMelding}, MeldingType: {mottattMeldingArgs.Melding.MeldingType} og lagrer i listen");
             MottatMeldingArgsList?.Add(mottattMeldingArgs);
             mottattMeldingArgs.SvarSender?.Ack();
         }
@@ -103,7 +103,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
                     throw new UnexpectedAnswerException($"Uforventet melding mottatt av typen {mottatMeldingArgs.Melding.MeldingType}. Forventet meldingstypen {forventetMeldingstype}.{Environment.NewLine} Feilmeldinger: {feilmeldinger.Count}{Environment.NewLine}{Environment.NewLine}{Environment.NewLine} {feilmeldingerString}");  
                 }
             }
-            Console.Out.WriteLineAsync($"Forventet meldingstype {forventetMeldingstype} mottatt for meldingsid  {sendtMeldingsid}!");
+            Console.Out.WriteLineAsync($"🎉 Forventet meldingstype {forventetMeldingstype} mottatt for meldingsid  {sendtMeldingsid}!");
         }
 
         protected static FeilmeldingBase HentUtFeilMelding(MottattMeldingArgs mottatMeldingArgs)

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/IntegrationTestsBase.cs
@@ -77,8 +77,9 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests
 
         protected static async void OnMottattMelding(object sender, MottattMeldingArgs mottattMeldingArgs)
         {
-            await Console.Out.WriteLineAsync($"Mottatt melding med MeldingId: {mottattMeldingArgs.Melding.MeldingId}, SvarPaMeldingId: {mottattMeldingArgs.Melding.SvarPaMelding}, MeldingType: {mottattMeldingArgs.Melding.MeldingType} og lagrer i listen");
-            MottatMeldingArgsList.Add(mottattMeldingArgs);
+            var shortMsgType = MeldingHelper.ShortenMessageType(mottattMeldingArgs);
+            await Console.Out.WriteLineAsync($"Mottatt {shortMsgType}-melding med MeldingId: {mottattMeldingArgs.Melding.MeldingId}, SvarPaMeldingId: {mottattMeldingArgs.Melding.SvarPaMelding}, MeldingType: {mottattMeldingArgs.Melding.MeldingType} og lagrer i listen");
+            MottatMeldingArgsList?.Add(mottattMeldingArgs);
             mottattMeldingArgs.SvarSender?.Ack();
         }
 

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/Sok/SokJournalpostTests.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/Sok/SokJournalpostTests.cs
@@ -96,7 +96,7 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Sok
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
             
             // Verifiser at man får mottatt melding
-            SjekkForventetMelding(MottatMeldingArgsList, sokMeldingId, FiksArkivMeldingtype.SokResultatUtvidet);
+            SjekkForventetMelding(sokMeldingId, FiksArkivMeldingtype.SokResultatUtvidet);
 
             // Hent melding
             var sokeresultatUtvidetMelding = GetMottattMelding(MottatMeldingArgsList, sokMeldingId,
@@ -121,7 +121,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Sok
 
         private async Task<Arkivmelding> ArkiverJournalpost(string testSessionId, string tittel)
         {
-            var arkivmelding = MeldingGenerator.CreateArkivmeldingMedNyJournalpost(FagsystemNavn, tittel: tittel);
+            var arkivmelding = MeldingGenerator.CreateArkivmelding(FagsystemNavn);
+            var referanse = GenererEksternNoekkel();
+            arkivmelding.Mappe = MappeBuilder.Init().WithKlassifikasjon(GenererKlassifikasjon()).BuildSaksmappe(referanse);
+            arkivmelding.Mappe.Tittel = tittel;
 
             var nyJournalpostSerialized = SerializeHelper.Serialize(arkivmelding);
             
@@ -144,10 +147,10 @@ namespace KS.Fiks.Arkiv.Integration.Tests.Tests.Sok
             Assert.True(MottatMeldingArgsList.Count > 0, "Fikk ikke noen meldinger innen timeout");
 
             // Verifiser at man får mottatt melding
-            SjekkForventetMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
+            SjekkForventetMelding(nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettMottatt);
 
             // Verifiser at man får arkivmeldingKvittering melding
-            SjekkForventetMelding(MottatMeldingArgsList, nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
+            SjekkForventetMelding(nyJournalpostMeldingId, FiksArkivMeldingtype.ArkivmeldingOpprettKvittering);
 
             // Hent melding
             var arkivmeldingKvitteringMelding = GetMottattMelding(MottatMeldingArgsList, nyJournalpostMeldingId,

--- a/KS.Fiks.Arkiv.Integration.Tests/Tests/TestHarness.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Tests/TestHarness.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using KS.Fiks.Arkiv.Integration.Tests.Helpers;
+using KS.Fiks.Arkiv.Models.V1.Arkivstruktur;
+using KS.Fiks.Arkiv.Models.V1.Meldingstyper;
+using KS.Fiks.IO.Client.Models;
+using KS.FiksProtokollValidator.Tests.IntegrationTests.Helpers;
+using KS.FiksProtokollValidator.Tests.IntegrationTests.Models;
+using KS.FiksProtokollValidator.Tests.IntegrationTests.Validation;
+using NUnit.Framework;
+
+namespace KS.Fiks.Arkiv.Integration.Tests.Tests;
+
+/// <summary>
+/// Brukes til å teste utsending av en melding, og sjekker at det returneres riktige meldinger tilbake.
+/// </summary>
+public class TestHarness
+{
+    public Guid mottakerKontoId;
+    public IntegrationTestsBase IntegrationTestsBase;
+    public Guid messageId;
+    public string meldingsType;
+    public string serialized;
+    public object payloadContent;
+    public List<KeyValuePair<string, FileStream>>? attachments;
+    public string? payloadFilename;
+    public int expectedReturnMessagesCount;
+    public bool expectedReturnMessagesCountAuto;
+    public int maxWait;
+    public IList<Action<MottattMeldingArgs>> expectedReturnMessages;
+    public List<MottattMeldingArgs> MottatMeldingArgsList;
+    private bool _sent;
+
+    public TestHarness(
+        IntegrationTestsBase integrationTestsBase,
+        string meldingsType,
+        object payloadContent,
+        int? expectedReturnMessagesCount = null,
+        List<KeyValuePair<string, FileStream>>? attachments = null,
+        string? payloadFilename = null,
+        Guid? mottakerKontoId = null,
+        int maxWait = 10
+    )
+    {
+        // TOOD: remove the reliance on the instance of IntegrationTestsBase here, we only need the base-config.
+        IntegrationTestsBase = integrationTestsBase;
+        MottatMeldingArgsList = new List<MottattMeldingArgs>();
+        IntegrationTestsBase.onMottatMelding = (o, args) => MottatMeldingArgsList.Add(args);
+        this.mottakerKontoId = mottakerKontoId ?? integrationTestsBase.MottakerKontoId;
+        this.meldingsType = meldingsType;
+        this.payloadContent = payloadContent;
+        this.attachments = attachments;
+        this.payloadFilename = payloadFilename;
+        if (expectedReturnMessagesCount == null)
+        {
+            this.expectedReturnMessagesCountAuto = true;
+        }
+
+        this.expectedReturnMessagesCount = expectedReturnMessagesCount ?? 0;
+        this.maxWait = maxWait;
+        Assert.True(FiksArkivMeldingtype.IsGyldigProtokollType(meldingsType));
+    }
+
+    public TestHarness ExpectToFail(string? messageType = null)
+    {
+        if (string.IsNullOrEmpty(messageType))
+        {
+            ExpectReceiveOneOfTypes(messageType);
+            return this;
+        }
+
+        ExpectReturnOfType(messageType);
+        return this;
+    }
+
+    public TestHarness ExpectReturnOfType(string messageType)
+    {
+        if (expectedReturnMessagesCountAuto)
+        {
+            expectedReturnMessagesCount++;
+        }
+
+        Vent();
+        IntegrationTestsBase.SjekkForventetMelding(messageId, messageType, MottatMeldingArgsList);
+        return this;
+    }
+
+    public TestHarness ExpectReceiveOneOfTypes(params string[] messageType)
+    {
+        if (expectedReturnMessagesCountAuto)
+        {
+            expectedReturnMessagesCount++;
+        }
+
+        Vent();
+        IntegrationTestsBase.SjekkForventetMelding(messageId, messageType, 1, MottatMeldingArgsList);
+        return this;
+    }
+
+    public TestHarness ExpectReceiveAllOfTypes(params string[] messageType)
+    {
+        if (expectedReturnMessagesCountAuto)
+        {
+            expectedReturnMessagesCount += messageType.Length;
+        }
+
+        Vent();
+        IntegrationTestsBase.SjekkForventetMelding(messageId, messageType, messageType.Length, MottatMeldingArgsList);
+        return this;
+    }
+
+    public (MottattMeldingArgs?, PayloadFile?) GetMelding(string meldingsType)
+    {
+        var melding =
+            IntegrationTestsBase.GetMottattMelding(MottatMeldingArgsList, messageId, meldingsType);
+        Assert.IsNotNull(melding);
+
+        var payload =
+            MeldingHelper.GetDecryptedMessagePayload(melding).Result;
+        Assert.IsNotNull(payload);
+        Assert.IsNotEmpty(payload.PayloadAsString);
+        return (melding, payload);
+
+    }
+    public (T?, MottattMeldingArgs?, PayloadFile?) GetMelding<T>(string meldingsType)
+    {
+        var (melding, payload) = GetMelding(meldingsType);
+        var deserialized = SerializeHelper.DeserializeXml<T>(payload.PayloadAsString);
+        return (deserialized, melding, payload);
+    }
+
+    public void Vent()
+    {
+        if (!_sent)
+        {
+            Send();
+        }
+
+        IntegrationTestsBase.VentPaSvar(expectedReturnMessagesCount, maxWait, MottatMeldingArgsList);
+        Assert.GreaterOrEqual(MottatMeldingArgsList.Count, expectedReturnMessagesCount,
+            "Fikk ikke forventet antall meldinger innen timeout");
+    }
+
+    public TestHarness Send()
+    {
+        serialized = SerializeHelper.Serialize(payloadContent);
+        var validator = new SimpleXsdValidator();
+        validator.Validate(serialized);
+        messageId = IntegrationTestsBase.FiksRequestService.Send(
+            mottakerKontoId,
+            meldingsType,
+            serialized,
+            attachments,
+            IntegrationTestsBase.TestSessionId,
+            payloadFilename
+        ).Result;
+        _sent = true;
+        Vent();
+        return this;
+    }
+}

--- a/KS.Fiks.Arkiv.Integration.Tests/Validation/SimpleXsdValidator.cs
+++ b/KS.Fiks.Arkiv.Integration.Tests/Validation/SimpleXsdValidator.cs
@@ -134,7 +134,7 @@ namespace KS.FiksProtokollValidator.Tests.IntegrationTests.Validation
                 {
                     Console.Out.WriteLineAsync($"XSD validation error {error}");
                 }
-                Assert.Fail("Validering med xsd feilet");
+                Assert.Fail($"Validering med xsd feilet: {string.Join(Environment.NewLine, validationHandler.errors)}");
             }
         }
     }


### PR DESCRIPTION
> Merk at denne PR'en bygger på https://github.com/ks-no/fiks-arkiv-integration-tests-dotnet/pull/9, som ikke er godkjent enda.

Forslag til en forenklet TestHarness som forenkler testing av utsending og validering av meldinger. Den tar seg av det mest vanlige, som serialisering/deserialisering og validering.

Underveis i implementasjonen ser jeg nok ikke burde ha basert den så mye fra IntegrationTestBase, da det ble litt krongelete å splitte det ut. Dette kan forbedres, om konseptet i seg selv virker som en god i ide.

Fordeler:

- Det blir enklere å opprette tester, med mindre kode, og mer relevant kode.
- Det er fortsatt mulig å bruke IntegrationTestBase som før.

Jeg har tatt i bruk denne i to tester, `Opprett_Saksmappe_Og_Journalpost_I_En_Melding` og `Hent_Journalpost_Med_Ikke_Eksisterende_EksternNoekkel_Returnerer_Ikkefunnet`. Koden her illustrerer godt hvordan koden blir mer konsis, etter min mening.
